### PR TITLE
Fix the imports to enable pip install

### DIFF
--- a/nnresample/__init__.py
+++ b/nnresample/__init__.py
@@ -1,4 +1,4 @@
 __version__ = '0.2.2'
 
-from nnresample.nnresample import resample, compute_filt
+from .nnresample import resample, compute_filt
 from . import utility

--- a/nnresample/nnresample.py
+++ b/nnresample/nnresample.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import scipy.signal as sig
 import numpy as np
-from nnresample.utility import disambiguate_params, As_from_beta
+from .utility import disambiguate_params, As_from_beta
 
 try:
     from math import gcd


### PR DESCRIPTION
Hey, 

This fixes the problems caused by the imports : 

- [This line](https://github.com/jthiem/nnresample/blob/master/nnresample/__init__.py#L3) was importing nnresample, which doesn't exist yet. Instead we use `import .nnresample` inside of the same folder.

- Exactly the same for [this line](https://github.com/jthiem/nnresample/blob/master/nnresample/nnresample.py#L4).