### PR TITLE
Include nnresample version in setup.py and remove scipy<2.0.0

### DIFF
--- a/nnresample/__init__.py
+++ b/nnresample/__init__.py
@@ -1,4 +1,2 @@
-__version__ = '0.2.3'
-
 from .nnresample import resample, compute_filt
 from . import utility

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,12 @@ from setuptools import setup, find_packages
 import nnresample
 
 setup(name='nnresample',
-      version=nnresample.__version__,
+      version=0.2.3,
       description='A resampling function based on placing the first null on Nyquist (Null-on-Nyquist Resample)',
       url='https://github.com/jthiem/nnresample',
       author='Joachim Thiemann',
       author_email='Joachim.Thiemann@gmail.com',
       license='CC-BY 3.0',
       packages=find_packages(include=['nnresample']),
-      install_requires=[
-          'scipy>=0.18.0,<2.0.0'  # NumPy is a dependancy of SciPy
-      ]
+      install_requires=['scipy>=0.18.0']
       )


### PR DESCRIPTION
Hi, 

Two things:
- Scipy's latest version is 1.0.0, so we can remove `'scipy<2.0.0'`
- Every package I saw, the version of the package is included in setup.py, not in __init.py__, so I did that.

Remark : I'm not sure if it makes sense to import nnresample inside of setup.py since I removed nnresample.__version__