### PR TITLE
Dev

### DIFF
--- a/nnresample/__init__.py
+++ b/nnresample/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.2.4.1'
+__version__ = '0.2.5'
 
 from .nnresample import resample, compute_filt
 from . import utility

--- a/nnresample/nnresample.py
+++ b/nnresample/nnresample.py
@@ -50,6 +50,10 @@ def compute_filt(up, down, fc='nn', beta=5.0, N=32001, return_fc=False):
     out = scipy.signal.resample_poly(in up, down, window=numpy.array(filt))
     """
 
+    # see explanation in resample below
+    if up==down:
+        raise ValueError('upsampling and downsampling rate cannot be the same.')
+
     # Determine our up and down factors
     g = gcd(up, down)
     up = up//g
@@ -150,6 +154,15 @@ def resample(s, up, down, axis=0, fc='nn', **kwargs):
     has previously been used it is looked up instead of being
     recomputed.
     """
+
+    # BUG FIX: if up==down, sig.fir_filter_design.firwin will throw
+    # an exception. In compute_filt that is OK (the user is assumed
+    # to know what they are doing if they use that function), but in
+    # the "user-friendly" resample function, we should just silently
+    # return a copy of the input. (Principle of least surprise)
+    # Thanks to johndoe46 on github for pointing this out.
+    if up==down:
+        return np.array(s)
 
     # from design parameters, find the generative parameters
     N, beta, As = disambiguate_params(**kwargs)

--- a/tests/test_nnresample.py
+++ b/tests/test_nnresample.py
@@ -1,50 +1,59 @@
+import unittest
+
 from nnresample.nnresample import compute_filt, resample
 from nnresample.utility import beta_from_As, As_from_beta, disambiguate_params
 from numpy import sum, cumsum, exp, log, sin, linspace, isclose, zeros, pi
 
-# test data
-t441 = linspace(0, 1, 44100)
-t480 = linspace(0, 1, 48000)
-ifreq441 = exp(linspace(log(100), log(20000), 22050))
-ifreq480 = exp(linspace(log(100), log(20000), 24000))
-refsig441 = zeros(44100)
-refsig480 = zeros(48000)
-refsig441[11025:33075] = sin(cumsum(ifreq441*2*pi/44100))
-refsig480[12000:36000] = sin(cumsum(ifreq480*2*pi/48000))
+class NNResampleUnittest(unittest.TestCase):
 
-def test_beta_from_As():
-    assert(isclose(beta_from_As(60), 5.65326))
-    assert(isclose(beta_from_As(30), 2.11662))
-    assert(isclose(beta_from_As(20), 0))
+    # test data
+    t441 = linspace(0, 1, 44100)
+    t480 = linspace(0, 1, 48000)
+    ifreq441 = exp(linspace(log(100), log(20000), 22050))
+    ifreq480 = exp(linspace(log(100), log(20000), 24000))
+    refsig441 = zeros(44100)
+    refsig480 = zeros(48000)
+    refsig441[11025:33075] = sin(cumsum(ifreq441*2*pi/44100))
+    refsig480[12000:36000] = sin(cumsum(ifreq480*2*pi/48000))
 
-def test_As_from_beta():
-    assert(isclose(60, As_from_beta(beta_from_As(60))))
-    assert(isclose(30, As_from_beta(beta_from_As(30))))
-    assert(isclose(25, As_from_beta(beta_from_As(25))))
+    def test_beta_from_As(self):
+        self.assertAlmostEqual(beta_from_As(60), 5.65326, places=5)
+        self.assertAlmostEqual(beta_from_As(30), 2.11662, places=5)
+        self.assertAlmostEqual(beta_from_As(20), 0)
 
-def test_disambiguate_params_default():
-    N, beta, As = disambiguate_params()
-    assert(N==32001)
-    assert(isclose(beta, 5.65326))
-    assert(isclose(As, 60))
+    def test_As_from_beta(self):
+        self.assertAlmostEqual(60, As_from_beta(beta_from_As(60)), places=5)
+        self.assertAlmostEqual(30, As_from_beta(beta_from_As(30)), places=5)
+        self.assertAlmostEqual(25, As_from_beta(beta_from_As(25)), places=5)
 
-def test_disambiguate_params_given_As():
-    N, beta, As = disambiguate_params(As=70)
-    assert(N==32001)
-    assert(isclose(beta, 6.75526))
-    assert(isclose(As, 70))
+    def test_disambiguate_params_default(self):
+        N, beta, As = disambiguate_params()
+        self.assertEqual(N, 32001)
+        self.assertAlmostEqual(beta, 5.65326)
+        self.assertAlmostEqual(As, 60)
 
-def test_compute_filt():
-    f = compute_filt(3, 2, N=1001)
-    assert(f.shape[0]==1001)
+    def test_disambiguate_params_given_As(self):
+        N, beta, As = disambiguate_params(As=70)
+        self.assertEqual(N, 32001)
+        self.assertAlmostEqual(beta, 6.75526)
+        self.assertAlmostEqual(As, 70)
 
-def test_compute_filt_invalid_arg():
-    try:
-        f = compute_filt(3, 2, fc='blah')
-    except Exception as e:
-        pass
+    def test_compute_filt(self):
+        f = compute_filt(3, 2, N=1001)
+        self.assertEqual(f.shape[0], 1001)
 
-def test_resample():
-    out = resample(refsig441, 480, 441)
-    diff = out - refsig480
-    assert(sum(diff**2)<100.0)
+    def test_compute_filt_invalid_arg(self):
+        self.assertRaises(ValueError, compute_filt, 3, 2, fc='blah')
+
+    def test_resample(self):
+        out = resample(self.refsig441, 480, 441)
+        diff = out - self.refsig480
+        self.assertAlmostEqual(sum(diff**2)/len(diff), 0, places=2)
+
+    def test_samerate(self):
+        out = resample(self.refsig441, 441, 441)
+        diff = out - self.refsig441
+        self.assertAlmostEqual(sum(diff**2)/len(diff), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_nnresample.py
+++ b/tests/test_nnresample.py
@@ -45,6 +45,9 @@ class NNResampleUnittest(unittest.TestCase):
     def test_compute_filt_invalid_arg(self):
         self.assertRaises(ValueError, compute_filt, 3, 2, fc='blah')
 
+    def test_compute_filt_samerate(self):
+        self.assertRaises(ValueError, compute_filt, self.refsig441, 441, 441)
+
     def test_resample(self):
         out = resample(self.refsig441, 480, 441)
         diff = out - self.refsig480


### PR DESCRIPTION
Adresses #13 

In compute_filt, the ValueError is thrown earlier to make it clear to the user what the problem is. In resample, the input signal is (silently) returned as an identical copy, because that is what the user should expect.

The tests have also been converted to the unittest framework.
